### PR TITLE
Adding Precheck Method, `is_git_installed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 2. `cd ducke`
 
-3. For debug : `cargo build` 
+3. For debug (or to build locally): `cargo build` 
    For release: `cargo build --release`
+
 
 4. To run debug : `./target/debug/ducke` 
    To run release : `./target/release/ducke` 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,21 @@
 use crossterm::event::{self, Event};
 use ratatui::{Frame, text::Text};
+mod utils;
 
 fn main() {
+    // Check for git BEFORE initializing the terminal
+    if !utils::is_git_installed() {
+        eprintln!("Error: Git is not installed or not in PATH");
+        eprintln!("Please install Git to use this application. For details see: https://git-scm.com/install/");
+        std::process::exit(1);
+    }
+
+    println!("✓ Git is installed and ready!");
+    std::thread::sleep(std::time::Duration::from_secs(3));
+
     let mut terminal = ratatui::init();
     loop {
         terminal.draw(draw).expect("failed to draw frame");
-
         if matches!(event::read().expect("failed to read event"), Event::Key(_)) {
             break;
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,9 @@
+use std::process::Command;
+
+pub fn is_git_installed() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}


### PR DESCRIPTION
## Description
- Adding a `utils.rs` file, that contains a function `is_git_installed()`. Git is a absolute requirement for ducke to run, therefore it makes sense to check at initalization for `git` to be installed. This is facilitated through a subprocess in rust which returns `true` or `false`, with both a positive and negative reinforcement message.


## Related Issue
Closes #15

## Demo (if visible change)

![ducke_precheck](https://github.com/user-attachments/assets/efa90f00-3ac3-432b-867f-7e8961c9b1eb)


## Checklist
- [x] Tests pass locally and in CI
- [x] No lint errors
- [x] I have self-reviewed my code